### PR TITLE
Sketch out initial message classes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,11 @@
 [run]
 branch = true
 
+[report]
+exclude_lines =
+  pragma: no cover
+  raise NotImplementedError
+  def __repr__
+
 [xml]
 output = coverage.xml

--- a/tchannel/messages.py
+++ b/tchannel/messages.py
@@ -1,0 +1,75 @@
+from __future__ import absolute_import
+
+from .types import Types
+from .parser import read_short
+from .parser import read_variable_length_key
+
+
+_BASE_FIELDS = (
+)
+
+
+class BaseMessage(object):
+    """Represent common functionality across all TChannel messages."""
+    # Micro-optimizations are the best kinds of optimizations
+    message_type = None
+    message_id = None
+
+    __slots__ = _BASE_FIELDS
+
+    def parse(self, payload, size):
+        """Parse a payload into a message.
+
+        This is defined by bytes 16 and above of the message body, e.g. after
+        the size and flags have been parsed.
+
+        Payload may be ``None`` if size is 0.
+        """
+        raise NotImplementedError()
+
+
+class InitRequestMessage(BaseMessage):
+    """Initialize a connection to a TChannel server."""
+    message_type = Types.INIT_REQ
+    VERSION_SIZE = 2
+
+    __slots__ = _BASE_FIELDS + (
+        'version',
+        'headers',
+    )
+
+    def parse(self, payload, size):
+        self.version = read_short(payload)
+        self.headers = {}
+
+        offset = self.VERSION_SIZE
+        while offset < size:
+            header_name, bytes_read = read_variable_length_key(payload, 2)
+            offset += bytes_read
+
+            header_value, bytes_read = read_variable_length_key(payload, 2)
+            offset += bytes_read
+
+            self.headers[header_name] = header_value
+
+
+class InitResponseMessage(InitRequestMessage):
+    """Respond to an initialization request message."""
+    message_type = Types.INIT_RES
+
+
+class CallRequestMessage(BaseMessage):
+    """Initiate an RPC call."""
+    message_type = Types.CALL_REQ
+
+    __slots__ = _BASE_FIELDS + (
+        # Zipkin-style tracing data
+        'span_id',
+        'parent_id',
+        'trace_id',
+    )
+
+
+class CallResponseMessage(CallRequestMessage):
+    """Respond to an RPC call."""
+    message_type = Types.CALL_RES

--- a/tchannel/parser.py
+++ b/tchannel/parser.py
@@ -1,0 +1,31 @@
+from __future__ import absolute_import
+
+import struct
+
+
+def read_big_endian(buffer, size):
+    """Read a big-endian number off the byte stream."""
+    if size == 1:
+        format = '>B'
+    elif size == 2:
+        format = '>H'
+    elif size == 4:
+        format = '>I'
+    else:
+        raise ValueError('size must be 1, 2, or 4')
+    return struct.unpack(format, buffer.read(size))[0]
+
+
+def read_short(buffer):
+    """Read two bytes in big-endian and return an unsigned integer."""
+    return read_big_endian(buffer, 2)
+
+
+def read_variable_length_key(buffer, key_size):
+    """Read a variable-length key from a stream.
+
+    Returns total number of bytes read, plus the value.
+    """
+    key_bytes = read_big_endian(buffer, key_size)
+    value = buffer.read(key_bytes)
+    return value, (key_bytes + key_size)

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import
+from cStringIO import StringIO
+import struct
+
+import pytest
+
+from tchannel import messages
+
+
+def make_byte_stream(bytes_):
+    return StringIO(bytes_), len(bytes_)
+
+
+def make_short_bytes(value):
+    """Convert value into a big-endian unsigned int."""
+    return struct.pack('>H', value)
+
+
+@pytest.fixture
+def init_request_message():
+    return make_byte_stream(make_short_bytes(0x02))
+
+
+@pytest.fixture
+def init_request_with_headers():
+    header_name = 'test_header'
+    header_value = 'something'
+    header_buffer = (
+        make_short_bytes(len(header_name)) +
+        header_name +
+        make_short_bytes(len(header_value)) +
+        header_value
+    )
+    return make_byte_stream(
+        make_short_bytes(0x02) +
+        header_buffer
+    )
+
+
+def test_message_type_applies():
+    """Verify message_type propagates."""
+    assert messages.InitRequestMessage().message_type > 0
+
+
+def test_init_request(init_request_message):
+    """Verify we can get an init request message to parse."""
+    message = messages.InitRequestMessage()
+    message.parse(*init_request_message)
+
+    assert message.version == 2
+
+
+def test_init_request_with_headers(init_request_with_headers):
+    message = messages.InitRequestMessage()
+    message.parse(*init_request_with_headers)
+
+    assert message.headers['test_header']

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,26 @@
+from __future__ import absolute_import
+from cStringIO import StringIO
+import struct
+
+import pytest
+
+from tchannel.parser import read_big_endian
+
+
+def test_read_char():
+    """Ensure reading a single character works."""
+    assert read_big_endian(StringIO(chr(0x10)), 1) == 16
+
+
+def test_read_long():
+    """Ensure we can read 4-byte longs."""
+    value = 12345
+    assert read_big_endian(StringIO(
+        struct.pack('>I', value)
+    ), 4) == value
+
+
+def test_read_invalid():
+    """Ensure size validation is enforced."""
+    with pytest.raises(ValueError):
+        read_big_endian(None, 42)


### PR DESCRIPTION
Add coverage configuration to ignore NotImplemented and __repr__ because
that is just for debugging.

Add number parsing and ensure we can parse headers properly on initialization requests.

@breerly @abhinav