### PR TITLE
Make protocol identifier a constant

### DIFF
--- a/tchannel/messages.py
+++ b/tchannel/messages.py
@@ -7,6 +7,7 @@ from .parser import read_key_value
 
 
 _BASE_FIELDS = ()
+PROTOCOL_VERSION = 0x02
 
 
 class BaseMessage(object):

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -37,7 +37,7 @@ def init_request_with_headers():
         header_value
     )
     return make_byte_stream(
-        make_short_bytes(0x02) +
+        make_short_bytes(messages.PROTOCOL_VERSION) +
         header_buffer
     )
 


### PR DESCRIPTION
Removing magic numbers because they're scary.

@uber/soap