### PR TITLE
Validate we round-trip UTF-8 properly

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from __future__ import absolute_import
 try:
     from cStringIO import StringIO
@@ -51,24 +52,26 @@ def test_write_number():
 
 
 def verify_key_value(stream, key, value, key_size, value_size):
-    assert read_number(stream, key_size) == len(key)
-    assert stream.read(len(key)).decode('utf-8') == key
+    utf8_key = key.encode('utf-8')
+    key_length = len(utf8_key)
+    assert read_number(stream, key_size) == key_length
+    assert stream.read(key_length).decode('utf-8') == key
 
-    if value:
-        assert read_number(stream, value_size) == len(value)
-        assert stream.read(len(value)).decode('utf-8') == value
-    else:
-        assert read_number(stream, value_size) == 0
+    value = value or ''
+    utf8_value = value.encode('utf-8')
+    value_length = len(utf8_value)
+    assert read_number(stream, value_size) == value_length
+    assert stream.read(value_length).decode('utf-8') == value
 
 
 @pytest.mark.parametrize('key_size,value_size,value', [
     (2, None, 'value'),
-    (2, 4, 'value'),
+    (2, 4, u"i'm a little snowman ☃"),
     (2, 2, None),
 ])
 def test_write_key_value(key_size, value_size, value, stringio):
     """Verify we write variable-width values properly."""
-    key = 'key'
+    key = u'key ☢'
 
     stream = write_key_value(
         key, value, key_size=key_size, value_size=value_size


### PR DESCRIPTION
Because I'm paranoid and these types of bugs are super common in Python.

@uber/soap 