### PR TITLE
Add zero-payload ping and pong message serialization

### DIFF
--- a/tchannel/messages.py
+++ b/tchannel/messages.py
@@ -101,6 +101,10 @@ class PingRequestMessage(BaseMessage):
         if size > 0:
             raise InvalidMessageException('Ping messages cannot have a body')
 
+    def serialize(self, out):
+        """Serialize nothing to the wire."""
+        return
+
 
 class PingResponseMessage(PingRequestMessage):
     """Respond to a ping request."""

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -77,6 +77,8 @@ def test_valid_ping_request():
 
 @pytest.mark.parametrize('message_class,attrs', [
     (messages.InitRequestMessage, {'headers': {'one': '2'}}),
+    (messages.PingRequestMessage, {}),
+    (messages.PingResponseMessage, {}),
 ])
 def test_serialize_message(message_class, attrs):
     """Verify all message types serialize properly."""


### PR DESCRIPTION
These messages are now ready to be round-tripped.

@uber/soap 