### PR TITLE
Lint examples/ directory in CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ commands =
   py.test --cov-report=term-missing {posargs}
 
 [testenv:flake8]
-commands = flake8 tchannel tests
+commands = flake8 tchannel examples tests
 
 [testenv:cover]
 commands =


### PR DESCRIPTION
To prevent dumb syntax errors and such.

@uber/soap