### PR TITLE
Consolidate tox and fasttest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,25 +7,24 @@ pytest := py.test -s --tb short --cov-config .coveragerc --cov \
 html_report := --cov-report html
 test_args := --cov-report term-missing
 
-.DEFAULT_GOAL := test
+.DEFAULT_GOAL := test-lint
 
-.PHONY: bootstrap
+.PHONY: bootstrap test test-lint testhtml clean lint
+
 bootstrap:
 	pip install -r requirements-test.txt
 	python setup.py develop
 
-.PHONY: test
 test: clean
 	$(pytest) $(test_args)
 
-.PHONY: testhtml
 testhtml: clean
 	$(pytest) $(html_report) && open htmlcov/index.html
 
-.PHYNO: clean
 clean:
 	@find $(project) -name "*.pyc" -delete
 
-.PHONY: lint
 lint:
-	$(flake8) $(project) tests
+	@$(flake8) $(project) tests examples
+
+test-lint: test lint

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ commands =
   py.test --cov-report=term-missing {posargs}
 
 [testenv:flake8]
-commands = flake8 tchannel examples tests
+commands = make lint
 
 [testenv:cover]
 commands =


### PR DESCRIPTION
`make` is used locally to quickly run the test suite. `tox` is used in
CI (for pull requests). They should run roughly the same set of
commands, and we shouldn't wait until CI to lint.

@uber/soap