### PR TITLE
Add error message roundtrip and refactor parser

### DIFF
--- a/tchannel/mapping.py
+++ b/tchannel/mapping.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import
 
-from .messages import InitRequestMessage
-from .messages import InitResponseMessage
 from .messages import CallRequestMessage
 from .messages import CallResponseMessage
+from .messages import ErrorMessage
+from .messages import InitRequestMessage
+from .messages import InitResponseMessage
 from .messages import PingRequestMessage
 from .messages import PingResponseMessage
 
@@ -15,6 +16,7 @@ ALL_MESSAGES = [
     CallResponseMessage,
     PingRequestMessage,
     PingResponseMessage,
+    ErrorMessage,
 ]
 
 MESSAGE_TYPES_TO_CLASSES = {

--- a/tchannel/messages.py
+++ b/tchannel/messages.py
@@ -118,13 +118,16 @@ class ErrorMessage(BaseMessage):
     message_type = Types.ERROR
     __slots__ = _BASE_FIELDS + (
         'code',
+        'original_message_id',
         'message',
     )
 
     def parse(self, payload, size):
         self.code = read_number(payload, 1)
+        self.original_message_id = read_number(payload, 4)
         self.message = read_variable_length_key(payload, 2)
 
     def serialize(self, out):
         out.extend(write_number(self.code, 1))
+        out.extend(write_number(self.original_message_id, 4))
         write_variable_length_key(out, self.message, 2)

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -72,10 +72,16 @@ def test_valid_ping_request():
 
 
 @pytest.mark.parametrize('message_class,attrs', [
-    (messages.InitRequestMessage, {'headers': {'one': '2'}}),
+    (messages.InitRequestMessage, {
+        'headers': {'one': '2'}
+    }),
     (messages.PingRequestMessage, {}),
     (messages.PingResponseMessage, {}),
-    (messages.ErrorMessage, {'code': 1, 'message': 'hi'}),
+    (messages.ErrorMessage, {
+        'code': 1,
+        'message': 'hi',
+        'original_message_id': 1
+    }),
 ])
 def test_serialize_message(message_class, attrs):
     """Verify all message types serialize properly."""
@@ -88,7 +94,7 @@ def test_serialize_message(message_class, attrs):
 
 
 @pytest.mark.parametrize('message_class,byte_stream', [
-    (messages.ErrorMessage, b'\x00\x00\x02hi')
+    (messages.ErrorMessage, b'\x00\x00\x00\x00\x01\x00\x02hi')
 ])
 def test_parse_message(message_class, byte_stream):
     """Verify all messages parse properly."""

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -75,6 +75,7 @@ def test_valid_ping_request():
     (messages.InitRequestMessage, {'headers': {'one': '2'}}),
     (messages.PingRequestMessage, {}),
     (messages.PingResponseMessage, {}),
+    (messages.ErrorMessage, {'code': 1, 'message': 'hi'}),
 ])
 def test_serialize_message(message_class, attrs):
     """Verify all message types serialize properly."""
@@ -84,3 +85,12 @@ def test_serialize_message(message_class, attrs):
         setattr(message, key, value)
 
     message.serialize(out)
+
+
+@pytest.mark.parametrize('message_class,byte_stream', [
+    (messages.ErrorMessage, b'\x00\x00\x02hi')
+])
+def test_parse_message(message_class, byte_stream):
+    """Verify all messages parse properly."""
+    message = message_class()
+    message.parse(BytesIO(byte_stream), len(byte_stream))


### PR DESCRIPTION
An Error message may now be sent/received. Moved the UTF-8
encoding/decoding down into the raw stream reader since everything
should be UTF-8 strings.

@uber/soap