### PR TITLE
Implement multi-frame parsing and full round-tripping

### DIFF
--- a/examples/tcp_client.py
+++ b/examples/tcp_client.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 
 import socket
 import sys
+import time
 
 from tchannel.socket import Connection
 
@@ -12,10 +13,14 @@ class MyClient(object):
         self.connection = Connection(connection)
 
         print("Initiating TChannel handshake...")
-        self.connection.initiate_handshake()
+        self.connection.initiate_handshake(headers={
+            'host_port': '%s:%s' % connection.getsockname(),
+            'process_name': sys.argv[0],
+        })
         print("Successfully completed handshake")
 
     def ping(self):
+        print("Ping...")
         self.connection.ping()
 
 
@@ -25,4 +30,9 @@ if __name__ == '__main__':
     sock.connect(('localhost', port))
     print("Connected to port %d..." % port)
     client = MyClient(sock)
+
     client.ping()
+    time.sleep(0.1)
+    client.ping()
+
+    print("All done")

--- a/examples/tcp_server.py
+++ b/examples/tcp_server.py
@@ -22,7 +22,10 @@ class MyHandler(SocketServer.BaseRequestHandler):
         print("Received request from %s:%d" % self.client_address)
 
         print("Waiting for TChannel handshake...")
-        tchannel_connection.await_handshake()
+        tchannel_connection.await_handshake(headers={
+            'host_port': '%s:%s' % self.request.getsockname(),
+            'process_name': sys.argv[0],
+        })
         print("Successfully completed handshake")
 
         # This call synchronously dispatches RPC requests to
@@ -34,7 +37,7 @@ class MyHandler(SocketServer.BaseRequestHandler):
 
     def handle_call(self, connection, context, message):
         """Handle a TChannel CALL_REQ message."""
-        print(context, message)
+        print("Received message: %s" % message)
 
 
 if __name__ == '__main__':

--- a/tchannel/frame.py
+++ b/tchannel/frame.py
@@ -44,11 +44,8 @@ class Frame(object):
         if not message_class:
             raise ProtocolException('Unknown message type: %d' % message_type)
 
-        partial = False
         flags = read_number(stream, cls.FLAGS_WIDTH)
-
-        if flags & cls.MORE_FRAMES_FLAG:
-            partial = True
+        partial = flags & cls.MORE_FRAMES_FLAG
 
         stream.read(cls.RESERVED_WIDTH)
         if not message:

--- a/tchannel/frame.py
+++ b/tchannel/frame.py
@@ -4,6 +4,7 @@ from .exceptions import ProtocolException
 from .io import BytesIO
 from .mapping import get_message_class
 from .parser import read_number
+from .parser import read_number_string
 from .parser import write_number
 
 
@@ -17,33 +18,83 @@ class Frame(object):
     RESERVED_PADDING = b'\x00\x00\x00\x00\x00\x00'  # 6 bytes are reserved
     RESERVED_WIDTH = len(RESERVED_PADDING)
 
-    def __init__(self, message, message_id):
+    MORE_FRAMES_FLAG = 0x01
+
+    def __init__(self, message, message_id, partial=False):
         self._message = message
         self._message_id = message_id
+        self.partial = partial
 
     @classmethod
-    def decode(cls, data):
+    def decode(cls, stream, message_length=None, message=None):
         """Decode a sequence of bytes into a frame and message."""
-        stream = BytesIO(data)
-        if len(data) < cls.PRELUDE_SIZE:
-            raise ProtocolException('Illegal frame length: %d' % len(data))
+        if message_length is None:
+            message_length = read_number(stream, cls.SIZE_WIDTH)
+        else:
+            stream.read(cls.SIZE_WIDTH)
 
-        message_length = read_number(stream, cls.SIZE_WIDTH)
+        if message_length < cls.PRELUDE_SIZE:
+            raise ProtocolException(
+                'Illegal frame length: %d' % message_length
+            )
+
         message_id = read_number(stream, cls.ID_WIDTH)
         message_type = read_number(stream, cls.TYPE_WIDTH)
         message_class = get_message_class(message_type)
         if not message_class:
             raise ProtocolException('Unknown message type: %d' % message_type)
 
+        partial = False
         flags = read_number(stream, cls.FLAGS_WIDTH)
-        if flags:
-            # TODO handle partial messages (e.g. multiple frames)
-            raise NotImplementedError("I don't understand flags yet!")
+
+        if flags & cls.MORE_FRAMES_FLAG:
+            partial = True
 
         stream.read(cls.RESERVED_WIDTH)
-        message = message_class()
+        if not message:
+            message = message_class()
         message.parse(stream, message_length - cls.PRELUDE_SIZE)
-        frame = cls(message=message, message_id=message_id)
+        frame = cls(message=message, message_id=message_id, partial=partial)
+
+        return frame, message
+
+    @classmethod
+    def read_full_frame(cls, stream, chunk_size, message=None):
+        """Read a full frame off the wire."""
+        chunk = stream.read(chunk_size)
+        if not chunk:
+            return None, None
+
+        message_length = read_number_string(
+            chunk[0:cls.SIZE_WIDTH],
+            cls.SIZE_WIDTH,
+        )[0]
+        if message_length > chunk_size:
+            rest_of_message = stream.read(message_length - chunk_size)
+            full_message = BytesIO(chunk + rest_of_message)
+        else:
+            full_message = BytesIO(chunk)
+
+        return cls.decode(full_message, message=message)
+
+    @classmethod
+    def read_full_message(cls, stream, chunk_size):
+        """Read a full message off the wire.
+
+        Possibly re-hydrating from multiple frames.
+        """
+        frame, message = cls.read_full_frame(stream, chunk_size)
+        if not frame:
+            return None, None
+
+        if frame.partial:
+            next_frame = frame
+            while next_frame.partial:
+                next_frame, message = cls.read_full_frame(
+                    stream,
+                    chunk_size,
+                    message=message,
+                )
 
         return frame, message
 

--- a/tchannel/messages.py
+++ b/tchannel/messages.py
@@ -49,6 +49,9 @@ class InitRequestMessage(BaseMessage):
     VERSION_SIZE = 2
     HEADER_SIZE = 2
 
+    HOST_PORT = 'host_port'
+    PROCESS_NAME = 'process_name'
+
     __slots__ = _BASE_FIELDS + (
         'version',
         'headers',

--- a/tchannel/parser.py
+++ b/tchannel/parser.py
@@ -19,6 +19,10 @@ def write_number(value, size):
     return struct.pack(get_number_format(size), value)
 
 
+def read_number_string(string, size):
+    return struct.unpack(get_number_format(size), string)
+
+
 def read_number(buff, size):
     """Read a big-endian number off the byte stream."""
     return struct.unpack(get_number_format(size), buff.read(size))[0]

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -96,6 +96,13 @@ def test_read_empty_buffer():
     assert Frame.read_full_message(BytesIO(), 4) == (None, None)
 
 
+def test_read_invalid_size(dummy_frame):
+    """Verify we raise when we try to read but get nothing."""
+    dummy_frame[3] = 0x20  # more bytes than are actually in dummy_frame
+    with pytest.raises(exceptions.ProtocolException):
+        assert Frame.read_full_message(BytesIO(dummy_frame), len(dummy_frame))
+
+
 def test_multi_frame(dummy_frame):
     """Ensure we read multiple frames into a message."""
     dummy_frame[8] = Types.PING_REQ

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -80,7 +80,7 @@ def test_decode_with_flags(dummy_frame):
 
 
 def test_read_full_small_chunk(connection, dummy_frame):
-    """Verify we can co-constitute from multiple reads."""
+    """Verify we can re-constitute from multiple reads."""
     frame = Frame(
         message=messages.PingRequestMessage(),
         message_id=42,
@@ -97,6 +97,7 @@ def test_read_empty_buffer():
 
 
 def test_multi_frame(dummy_frame):
+    """Ensure we read multiple frames into a message."""
     dummy_frame[8] = Types.PING_REQ
     first_frame = bytearray(dummy_frame)
     second_frame = bytearray(dummy_frame)

--- a/tests/test_frame.py
+++ b/tests/test_frame.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 import pytest
 
 from tchannel import exceptions
+from tchannel import messages
 from tchannel.frame import Frame
 from tchannel.io import BytesIO
 from tchannel.parser import read_number
@@ -47,26 +48,60 @@ def test_empty_message(connection):
 def test_decode_empty_buffer():
     """Verify we raise on invalid buffers."""
     with pytest.raises(exceptions.ProtocolException):
-        Frame.decode(b'')
+        Frame.decode(BytesIO(b'\x00\x00\x00\x00'))
+
+
+def test_decode_with_message_length(dummy_frame):
+    """Verify we can pre-flight a message size."""
+    dummy_frame[8] = Types.PING_REQ
+    Frame.decode(BytesIO(dummy_frame), len(dummy_frame))
 
 
 def test_decode_invalid_message_id(dummy_frame):
     """Verify we raise on invalid message IDs."""
-    dummy_frame[8] = 55  # not a real message ID
+    dummy_frame[8] = 55  # not a real message type
     with pytest.raises(exceptions.ProtocolException):
-        Frame.decode(dummy_frame)
+        Frame.decode(BytesIO(dummy_frame))
 
 
 def test_decode_ping(dummy_frame):
     """Verify we can decode a ping message."""
     dummy_frame[8] = Types.PING_REQ
-    frame, message = Frame.decode(dummy_frame)
+    frame, message = Frame.decode(BytesIO(dummy_frame))
 
 
 def test_decode_with_flags(dummy_frame):
-    """Verify we handle flags (not implemented yet)."""
+    """Verify we handle the `partial` flag."""
     dummy_frame[8] = Types.PING_REQ
     dummy_frame[9] = 0x01
 
-    with pytest.raises(NotImplementedError):
-        Frame.decode(dummy_frame)
+    frame, _ = Frame.decode(BytesIO(dummy_frame))
+    assert frame.partial
+
+
+def test_read_full_small_chunk(connection, dummy_frame):
+    """Verify we can co-constitute from multiple reads."""
+    frame = Frame(
+        message=messages.PingRequestMessage(),
+        message_id=42,
+    )
+    frame.write(connection)
+
+    frame, message = Frame.read_full_message(BytesIO(connection.getvalue()), 4)
+    assert message.message_type == Types.PING_REQ
+
+
+def test_read_empty_buffer():
+    """Verify we handle an empty buffer."""
+    assert Frame.read_full_message(BytesIO(), 4) == (None, None)
+
+
+def test_multi_frame(dummy_frame):
+    dummy_frame[8] = Types.PING_REQ
+    first_frame = bytearray(dummy_frame)
+    second_frame = bytearray(dummy_frame)
+
+    first_frame[9] = 0x01
+
+    connection = BytesIO(first_frame + second_frame)
+    frame, message = Frame.read_full_message(connection, 16)

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -68,6 +68,7 @@ def test_ping(tchannel_pair):
 
 
 def test_handle_calls(tchannel_pair):
+    """Verify handle_calls sends the message to our handler."""
     class _MyException(Exception):
         pass
 
@@ -81,6 +82,7 @@ def test_handle_calls(tchannel_pair):
 
 
 def test_finish_connection(tchannel_pair):
+    """Ensure we break out of the endless loop when client closes."""
     server, client = tchannel_pair
     client.ping()
     client._connection._connection.close()


### PR DESCRIPTION
This commit closes many of the loops around sending and receiving
messages. There is one outstanding issue in that if you pipeline two
requests in the same TCP packet, the second one will be lost.

@uber/soap