### PR TITLE
Fix message API documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,12 +5,45 @@ TChannel API
 Messages
 --------
 
-.. automodule:: tchannel.messages
+.. automodule:: tchannel.messages.base
     :members:
-    :show-inheritance:
+
+.. automodule:: tchannel.messages.call_request
+    :members:
+
+.. automodule:: tchannel.messages.call_request_continue
+    :members:
+
+.. automodule:: tchannel.messages.call_response
+    :members:
+
+.. automodule:: tchannel.messages.call_response_continue
+    :members:
+
+.. automodule:: tchannel.messages.error
+    :members:
+
+.. automodule:: tchannel.messages.init_request
+    :members:
+
+.. automodule:: tchannel.messages.init_response
+    :members:
+
+.. automodule:: tchannel.messages.ping_request
+    :members:
+
+.. automodule:: tchannel.messages.ping_response
+    :members:
 
 Framing
 -------
 
 .. automodule:: tchannel.frame
+    :members:
+
+
+Exceptions
+----------
+
+.. automodule:: tchannel.exceptions
     :members:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,35 +5,10 @@ TChannel API
 Messages
 --------
 
-.. automodule:: tchannel.messages.base
+.. automodule:: tchannel.messages
     :members:
+    :imported-members:
 
-.. automodule:: tchannel.messages.call_request
-    :members:
-
-.. automodule:: tchannel.messages.call_request_continue
-    :members:
-
-.. automodule:: tchannel.messages.call_response
-    :members:
-
-.. automodule:: tchannel.messages.call_response_continue
-    :members:
-
-.. automodule:: tchannel.messages.error
-    :members:
-
-.. automodule:: tchannel.messages.init_request
-    :members:
-
-.. automodule:: tchannel.messages.init_response
-    :members:
-
-.. automodule:: tchannel.messages.ping_request
-    :members:
-
-.. automodule:: tchannel.messages.ping_response
-    :members:
 
 Framing
 -------


### PR DESCRIPTION
Fallout from reorganization earlier today. Also adds exceptions to
documentation.

@uber/soap