### PR TITLE
Add call request body round-tripping

### DIFF
--- a/tchannel/messages/base.py
+++ b/tchannel/messages/base.py
@@ -1,5 +1,10 @@
 from __future__ import absolute_import
 
+from ..parser import read_key_value
+from ..parser import read_number
+from ..parser import write_number
+from ..parser import write_key_value
+
 
 class BaseMessage(object):
     """Represent common functionality across all TChannel messages."""
@@ -24,3 +29,31 @@ class BaseMessage(object):
         This generates the ``payload`` section of the message.
         """
         raise NotImplementedError()
+
+    def _read_headers(self, stream, nh_size, header_size):
+        """Read a variable number of headers.
+
+        Returns a tuple of (headers dict, bytes read)"""
+        num_headers = read_number(stream, nh_size)
+        bytes_read = nh_size
+
+        headers = {}
+        for _ in range(num_headers):
+            header_name, header_value, num_bytes = read_key_value(
+                stream,
+                header_size
+            )
+            headers[header_name] = header_value
+            bytes_read += num_bytes
+
+        return headers, bytes_read
+
+    def _write_headers(self, stream, headers, nh_size, header_size):
+        """Write number of headers followed by headers.
+
+        Format:
+            nh~nh_size (hk~header_size hv~header_size){nh}
+        """
+        stream.extend(write_number(len(headers), nh_size))
+        for key, value in headers.items():
+            stream.extend(write_key_value(key, value, key_size=header_size))

--- a/tchannel/messages/base.py
+++ b/tchannel/messages/base.py
@@ -33,7 +33,8 @@ class BaseMessage(object):
     def _read_headers(self, stream, nh_size, header_size):
         """Read a variable number of headers.
 
-        Returns a tuple of (headers dict, bytes read)"""
+        Returns a tuple of (headers dict, bytes read).
+        """
         num_headers = read_number(stream, nh_size)
         bytes_read = nh_size
 

--- a/tchannel/messages/call_request.py
+++ b/tchannel/messages/call_request.py
@@ -2,6 +2,10 @@ from __future__ import absolute_import
 
 from .base import BaseMessage
 from .types import Types
+from ..parser import read_number
+from ..parser import read_variable_length_key
+from ..parser import write_number
+from ..parser import write_variable_length_key
 
 
 class CallRequestMessage(BaseMessage):
@@ -18,10 +22,103 @@ class CallRequestMessage(BaseMessage):
         'trace_id',
 
         'traceflags',
+
         'service',
         'headers',
 
-        'arg1',
-        'arg2',
-        'arg3',
+        'checksum_type',
+        'checksum',
+
+        'arg_1',
+        'arg_2',
+        'arg_3',
     )
+
+    FLAGS_SIZE = 1
+    TTL_SIZE = 4
+    TRACE_SIZE = 8
+    TRACEFLAGS_SIZE = 1
+    SERVICE_SIZE = 2
+    NH_SIZE = 1
+    HEADER_SIZE = 1
+    CSUMTYPE_SIZE = 1
+    CSUM_SIZE = 4
+
+    ARG_SIZE = 2
+
+    def parse(self, payload, size):
+        """Parse a call request message from a payload."""
+        self.flags = read_number(payload, self.FLAGS_SIZE)
+        self.ttl = read_number(payload, self.TTL_SIZE)
+
+        self.span_id = read_number(payload, self.TRACE_SIZE)
+        self.parent_id = read_number(payload, self.TRACE_SIZE)
+        self.trace_id = read_number(payload, self.TRACE_SIZE)
+
+        self.traceflags = read_number(payload, self.TRACEFLAGS_SIZE)
+
+        self.service, _ = read_variable_length_key(payload, self.SERVICE_SIZE)
+
+        self.headers, _ = self._read_headers(
+            payload,
+            self.NH_SIZE,
+            self.HEADER_SIZE,
+        )
+
+        self.checksum_type = read_number(payload, self.CSUMTYPE_SIZE)
+        if self.checksum_type:
+            self.checksum = read_number(payload, self.CSUM_SIZE)
+
+        # TODO check if we're at the end of the stream by counting bytes
+        self.arg_1, _ = read_variable_length_key(
+            payload,
+            self.ARG_SIZE,
+            decode=False,
+        )
+        self.arg_2, _ = read_variable_length_key(
+            payload,
+            self.ARG_SIZE,
+            decode=False,
+        )
+        self.arg_3, _ = read_variable_length_key(
+            payload,
+            self.ARG_SIZE,
+            decode=False,
+        )
+
+    def serialize(self, out):
+        """Write a call request message out to a buffer."""
+        out.extend(write_number(self.flags, self.FLAGS_SIZE))
+        out.extend(write_number(self.ttl, self.TTL_SIZE))
+
+        out.extend(write_number(self.span_id, self.TRACE_SIZE))
+        out.extend(write_number(self.parent_id, self.TRACE_SIZE))
+        out.extend(write_number(self.trace_id, self.TRACE_SIZE))
+        out.extend(write_number(self.traceflags, self.TRACEFLAGS_SIZE))
+
+        write_variable_length_key(out, self.service, self.SERVICE_SIZE)
+
+        self._write_headers(out, self.headers, self.NH_SIZE, self.HEADER_SIZE)
+
+        out.extend(write_number(self.checksum_type, self.CSUMTYPE_SIZE))
+        if self.checksum_type:
+            out.extend(write_number(self.checksum, self.CSUM_SIZE))
+
+        write_variable_length_key(
+            out,
+            self.arg_1,
+            self.ARG_SIZE,
+            encode=False,
+        )
+        write_variable_length_key(
+            out,
+            self.arg_2,
+            self.ARG_SIZE,
+            encode=False,
+        )
+        write_variable_length_key(
+            out,
+            self.arg_3,
+            self.ARG_SIZE,
+            encode=False,
+        )

--- a/tchannel/messages/error.py
+++ b/tchannel/messages/error.py
@@ -20,7 +20,7 @@ class ErrorMessage(BaseMessage):
     def parse(self, payload, size):
         self.code = read_number(payload, 1)
         self.original_message_id = read_number(payload, 4)
-        self.message = read_variable_length_key(payload, 2)
+        self.message, _ = read_variable_length_key(payload, 2)
 
     def serialize(self, out):
         out.extend(write_number(self.code, 1))

--- a/tchannel/parser.py
+++ b/tchannel/parser.py
@@ -10,8 +10,10 @@ def get_number_format(size):
         return '>H'
     elif size == 4:
         return '>I'
+    elif size == 8:
+        return '>Q'
     else:
-        raise ValueError('size must be 1, 2, or 4')
+        raise ValueError('size must be 1, 2, 4, or 8, not %d' % size)
 
 
 def write_number(value, size):
@@ -33,14 +35,18 @@ def read_short(buff):
     return read_number(buff, 2)
 
 
-def read_variable_length_key(buff, key_size):
+def read_variable_length_key(buff, key_size, decode=True):
     """Read a variable-length key from a stream.
 
     Returns tuple of (value, bytes read).
     """
     key_bytes = read_number(buff, key_size)
-    value = buff.read(key_bytes)
-    return value.decode('utf-8'), (key_bytes + key_size)
+    if key_bytes:
+        value = buff.read(key_bytes)
+        return_value = value.decode('utf-8') if decode else value
+    else:
+        return_value = None
+    return return_value, (key_bytes + key_size)
 
 
 def read_key_value(buff, key_size, value_size=None):
@@ -60,11 +66,18 @@ def read_key_value(buff, key_size, value_size=None):
     return key, value, (key_bytes + value_bytes)
 
 
-def write_variable_length_key(stream, value, value_size):
+def write_variable_length_key(stream, value, value_size, encode=True):
     """Write a length followed by that many bytes."""
-    encoded_value = value.encode('utf-8')
-    stream.extend(write_number(len(encoded_value), value_size))
-    stream.extend(encoded_value)
+    if value:
+        encoded_value = value.encode('utf-8') if encode else value
+        value_length = len(encoded_value)
+    else:
+        encoded_value = None
+        value_length = 0
+
+    stream.extend(write_number(value_length, value_size))
+    if encoded_value:
+        stream.extend(encoded_value)
 
 
 def write_key_value(key, value, key_size, value_size=None):

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -20,7 +20,10 @@ def make_short_bytes(value):
 
 @pytest.fixture
 def init_request_message():
-    return make_byte_stream(make_short_bytes(0x02))
+    return make_byte_stream(
+        make_short_bytes(0x02) +  # version 2
+        make_short_bytes(0)  # 0 headers
+    )
 
 
 @pytest.fixture
@@ -84,15 +87,50 @@ def test_valid_ping_request():
         'message': 'hi',
         'original_message_id': 1,
     }),
+    (messages.CallRequestMessage, {
+        'flags': 0,
+        'ttl': 1,
+        'span_id': 0,
+        'parent_id': 0,
+        'trace_id': 0,
+        'traceflags': 0,
+        'service': 'kodenom',
+        'headers': {},
+        'checksum_type': 0,
+        'arg_1': None,
+        'arg_2': None,
+        'arg_3': None,
+    }),
+    (messages.CallRequestMessage, {
+        'flags': 0x01,
+        'ttl': 1,
+        'span_id': 0,
+        'parent_id': 0,
+        'trace_id': 0,
+        'traceflags': 0x01,
+        'service': 'with_checksum',
+        'headers': {},
+        'checksum_type': 1,
+        'checksum': 3,
+        'arg_1': 'hi',
+        'arg_2': b'\x00',
+        'arg_3': None,
+    })
 ])
-def test_serialize_message(message_class, attrs):
-    """Verify all message types serialize properly."""
+def test_roundtrip_message(message_class, attrs):
+    """Verify all message types serialize and deserialize properly."""
     message = message_class()
-    out = bytearray()
     for key, value in attrs.items():
         setattr(message, key, value)
 
+    out = bytearray()
     message.serialize(out)
+
+    in_message = message_class()
+    in_message.parse(BytesIO(out), len(out))
+
+    for key, value in attrs.items():
+        assert getattr(in_message, key) == value
 
 
 @pytest.mark.parametrize('message_class,byte_stream', [

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -112,7 +112,7 @@ def test_valid_ping_request():
         'headers': {},
         'checksum_type': 1,
         'checksum': 3,
-        'arg_1': 'hi',
+        'arg_1': b'hi',
         'arg_2': b'\x00',
         'arg_3': None,
     })


### PR DESCRIPTION
This implements happy-path round-tripping for CallRequest messages and
fixes a bug or two along the way. It also adds a deserialization step to
the message tests to ensure symmetry in implementations.

@uber/soap